### PR TITLE
Add a new RFC/design drafts subcategory

### DIFF
--- a/docs/background-information/design/_category_.json
+++ b/docs/background-information/design/_category_.json
@@ -1,5 +1,5 @@
 {
-	"label": "Design Patterns",
+	"label": "Design Documents",
 	"position": 1,
 	"link": {
 	  "type": "generated-index",

--- a/docs/background-information/design/drafts/_category_.json
+++ b/docs/background-information/design/drafts/_category_.json
@@ -1,0 +1,8 @@
+{
+	"label": "Drafts",
+	"position": 1,
+	"link": {
+	  "type": "generated-index",
+	  "description": "RFCs and other unfinished design documents"
+	}
+  }

--- a/docs/background-information/design/drafts/unit-test-runner.md
+++ b/docs/background-information/design/drafts/unit-test-runner.md
@@ -1,0 +1,24 @@
+# RFC: Standardized Unit Test Runner
+
+This document describes potential designs for a BDD-style test runner.
+
+## Motivation
+
+There's a need for unit testing, but the existing frameworks are largely inactive and can't easily be adapted.
+
+## Testing Philosophy
+
+BDD style, meaning ``describe`` and ``it`` is used to define test suites. Why?
+
+* Easy to understand
+* Similar to the existing frameworks
+* Requires little boilerplate
+* Flexible enough for all basic unit testing needs
+* Simple enough to implement from scratch
+* Lends itself well to domain-driven design
+
+## Alternatives
+
+* Make ``busted`` work the way it should (painful)
+* Attempt to fit ``luaunit`` into the BDD framework (impedance mismatch)
+* Try out some of more niche frameworks listed on [lua-users.org](http://lua-users.org/wiki/UnitTesting) (unlikely to be fruitful)


### PR DESCRIPTION
Also renames Design Patterns to Design Documents, as that's a more apt name considering these new contents.