### PR TITLE
Fix the invisible border of navigation bar links on hover

### DIFF
--- a/src/css/navigation-bar.css
+++ b/src/css/navigation-bar.css
@@ -39,7 +39,6 @@
 
 .navbar__link:hover {
   transition: all 0.5s ease;
-  border-color: var(--text-color-green);
   border-width: 2px;
   color: var(--text-color-green);
   background-color: white;


### PR DESCRIPTION
It's supposed to use the same color as the background, but I didn't see.