### PR TITLE
Add coreutils to the list of Mac OS build prerequisites

### DIFF
--- a/docs/how-to-guides/building-from-source.md
+++ b/docs/how-to-guides/building-from-source.md
@@ -46,7 +46,7 @@ A complete setup procedure involves the following steps:
 
 1. Download the [Homebrew package manager](https://brew.sh/)
 1. Install Apple's compiler toolchain: `xcode-select --install`
-1. Install the required build tools: `brew install git cmake ninja`
+1. Install the required build tools: `brew install git cmake ninja coreutils`
 
 You should be able to execute `gcc`, `g++`, `cmake`, and `ninja` in your terminal before starting the build.
 


### PR DESCRIPTION
This is "required" to build openssl with multiple cores, because the build script uses nproc to determine the parallelism factor.

There's probably another way to do that on Mac OS, but I didn't bother to figure it out (and this approach also works on Linux).