### PR TITLE
Fix a visual glitch with the API structure tables

### DIFF
--- a/src/components/API/styles.module.css
+++ b/src/components/API/styles.module.css
@@ -10,7 +10,6 @@
   display: inline-block;
   margin: 0;
   margin-right: 1.5em;
-  box-shadow: 1px 1px 1px 1px rgba(0, 0, 0, 0.05);
 }
 
 /* Assumes these won't ever occur without a return or args table*/


### PR DESCRIPTION
The shadow extends visibly into the void when the number of rows differs between two adjacent tables.

Example:

![image](https://user-images.githubusercontent.com/16489133/227305475-c70e5aa7-1bfe-46d6-a44d-52f5c709a184.png)
