### PR TITLE
Use date-fns to format the release date on the front page instead of a simplistic homebrew algorithm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@docusaurus/preset-classic": "^2.4.0",
         "@mdx-js/react": "^1.6.22",
         "clsx": "^1.1.1",
+        "date-fns": "^2.30.0",
         "prettier": "^2.8.8",
         "prism-react-renderer": "^2.0.3",
         "react": "^17.0.2",
@@ -1897,9 +1898,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.20.13",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.13.tgz",
-      "integrity": "sha512-gt3PKXs0DBoL9xCvOIIZ2NEqAGZqHjAnmVbfQtB620V0uReIQutpel14KcneZuer7UioY8ALKZ7iocavvzTNFA==",
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.5.tgz",
+      "integrity": "sha512-8jI69toZqqcsnqGGqwGS4Qb1VwLOEp4hz+CXPywcvjs60u3B4Pom/U/7rm4W8tMOYEB+E9wgD0mW1l3r8qlI9Q==",
       "dependencies": {
         "regenerator-runtime": "^0.13.11"
       },
@@ -5152,6 +5153,21 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.0.tgz",
       "integrity": "sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA=="
+    },
+    "node_modules/date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
+      }
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -13766,9 +13782,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.20.13",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.13.tgz",
-      "integrity": "sha512-gt3PKXs0DBoL9xCvOIIZ2NEqAGZqHjAnmVbfQtB620V0uReIQutpel14KcneZuer7UioY8ALKZ7iocavvzTNFA==",
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.5.tgz",
+      "integrity": "sha512-8jI69toZqqcsnqGGqwGS4Qb1VwLOEp4hz+CXPywcvjs60u3B4Pom/U/7rm4W8tMOYEB+E9wgD0mW1l3r8qlI9Q==",
       "requires": {
         "regenerator-runtime": "^0.13.11"
       }
@@ -16188,6 +16204,14 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.0.tgz",
       "integrity": "sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA=="
+    },
+    "date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "requires": {
+        "@babel/runtime": "^7.21.0"
+      }
     },
     "debug": {
       "version": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@docusaurus/preset-classic": "^2.4.0",
     "@mdx-js/react": "^1.6.22",
     "clsx": "^1.1.1",
+    "date-fns": "^2.30.0",
     "prettier": "^2.8.8",
     "prism-react-renderer": "^2.0.3",
     "react": "^17.0.2",

--- a/src/components/LatestRelease/index.jsx
+++ b/src/components/LatestRelease/index.jsx
@@ -8,38 +8,6 @@ function LatestReleaseButton() {
   const [releaseInfo, setReleaseInfo] = useState("");
   const [assets, setAssets] = useState([]);
 
-  const getAccurateTimeDifference = (timeDifference) => {
-    const seconds = Math.floor(timeDifference / 1000);
-    const minutes = Math.floor(seconds / 60);
-    const hours = Math.floor(minutes / 60);
-
-    if (hours > 0) {
-      return `${hours} hours ago`;
-    } else if (minutes > 0) {
-      return `${minutes} minutes ago`;
-    } else {
-      return `${seconds} seconds ago`;
-    }
-  };
-
-  const getTimeDifferenceInDays = (timeDifference) => {
-    return `${Math.floor(timeDifference / MILLISECONDS_PER_DAY)} days ago`;
-  };
-
-  const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1000;
-
-  const getHumanReadableTimeDifference = (releaseDate) => {
-    const now = new Date();
-    const timeDifference = now - releaseDate;
-
-    const wasLastReleaseToday = timeDifference < MILLISECONDS_PER_DAY;
-    const humanReadableTimeDiff = wasLastReleaseToday
-      ? getAccurateTimeDifference(timeDifference)
-      : getTimeDifferenceInDays(timeDifference);
-
-    return humanReadableTimeDiff;
-  };
-
   useEffect(() => {
     fetch("https://api.github.com/repos/evo-lua/evo-runtime/releases/latest")
       .then((response) => response.json())

--- a/src/components/LatestRelease/index.jsx
+++ b/src/components/LatestRelease/index.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import formatDistanceToNowStrict from "date-fns/formatDistanceToNowStrict";
 
 function LatestReleaseButton() {
   const [downloadUrl, setDownloadUrl] = useState(
@@ -51,11 +52,11 @@ function LatestReleaseButton() {
         setAssets(assets);
 
         const humanReadableTimeDifference =
-          getHumanReadableTimeDifference(releaseDate);
+          formatDistanceToNowStrict(releaseDate);
 
         setDownloadUrl(releaseUrl);
         setReleaseInfo(
-          `Latest Release: ${releaseTag} (${humanReadableTimeDifference})`
+          `Latest Release: ${releaseTag} (${humanReadableTimeDifference} ago)`
         );
       })
       .catch((error) => {


### PR DESCRIPTION
It doesn't work in some edge cases and there's no point in reinventing the wheel for this minor task.