### PR TITLE
Remove the placeholder CLI reference

### DIFF
--- a/docs/references/api/namespaces/runtime.md
+++ b/docs/references/api/namespaces/runtime.md
@@ -4,7 +4,7 @@ sidebar_position: 30
 
 # C_Runtime
 
-Implementation of the runtime's [command-line interface](/docs/references/command-line-interface) (CLI)
+Implementation of the runtime's command-line interface (CLI)
 
 ## Status
 
@@ -20,7 +20,7 @@ C_Runtime.PrintVersionString() -- Implicit global lookup: _G.C_Runtime
 
 ### DisplayHelpText
 
-Displays a text containing versioning information and some basic usage instructions for the runtime's [command-line interface](/docs/references/command-line-interface).
+Displays a text containing versioning information and some basic usage instructions for the runtime's command-line interface.
 
 ### EvaluateString
 

--- a/docs/references/command-line-interface.md
+++ b/docs/references/command-line-interface.md
@@ -1,9 +1,0 @@
----
-sidebar_position: 1
----
-
-# Command-Line Interface (Placeholder)
-
-A list of available command-line options for the evo runtime
-
-<Placeholder/>


### PR DESCRIPTION
After the latest redesign and simplification, I don't see there being a need to document the CLI usage. There's only a few more important things to add to it, too, so let's keep things simple.