### PR TITLE
Fix a dead link on the landing page

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -44,7 +44,7 @@ function DownloadArea() {
         </Link>
         <Link
           className="hero-text"
-          to="/docs/getting-started/evo-in-a-nutshell#how-can-users-get-support"
+          to="https://github.com/evo-lua/evo-runtime/issues/new"
         >
           Report a Problem
         </Link>


### PR DESCRIPTION
Not sure if just linking to the issues would be better as this requires a GitHub account... but realistically, who doesn't have one these days?