### PR TITLE
Improve the description of the Delete method

### DIFF
--- a/docs/references/api/namespaces/filesystem.md
+++ b/docs/references/api/namespaces/filesystem.md
@@ -36,7 +36,7 @@ Opens the given `filePath` in append mode and writes `contents` to the end of th
 
 <Blocking/>
 
-Irrevocably removes the file or directory referenced by the given `fileSystemPath`. This operation cannot be undone.
+Removes the file or directory referenced by the given `fileSystemPath`. This operation cannot be undone.
 
 <Function>
 <Parameters>


### PR DESCRIPTION
This is redundant since the second paragraph already states that the operation is irrevocable.