### PR TITLE
Add an API reference for the regex library

### DIFF
--- a/docs/references/api/bindings/regex.md
+++ b/docs/references/api/bindings/regex.md
@@ -1,0 +1,31 @@
+# regex
+
+Lua bindings for the embedded [PCRE2](https://github.com/PCRE2Project/pcre2) library
+
+## Status
+
+<External/>
+
+## Availability
+
+This module is preloaded. You can simply `require` it:
+
+```lua
+local regex = require("regex")
+```
+
+## Functions
+
+For a detailed API documentation, see [http://rrthomas.github.io/lrexlib/manual.html](http://rrthomas.github.io/lrexlib/manual.html)
+
+:::info
+
+There's just one minor cosmetic difference: All exported functions are exactly the same, but the `rex` library is called `regex` in Evo.
+
+:::
+
+## Changelog
+
+| Version | What happened?  |
+| :-----: | :-------------: |
+| v0.0.5  | Initial release |


### PR DESCRIPTION
Not much going on here as the functions are 1:1 from lrexlib.

Listing the library should help with discoverability regardless.