### PR TITLE
Display a placeholder loading text while fetching the latest release

### DIFF
--- a/src/components/LatestRelease/index.jsx
+++ b/src/components/LatestRelease/index.jsx
@@ -5,7 +5,9 @@ function LatestReleaseButton() {
   const [downloadUrl, setDownloadUrl] = useState(
     "https://github.com/evo-lua/evo-runtime/releases"
   );
-  const [releaseInfo, setReleaseInfo] = useState("");
+  const [releaseInfo, setReleaseInfo] = useState(
+    "Fetching latest release info..."
+  );
   const [assets, setAssets] = useState([]);
 
   useEffect(() => {


### PR DESCRIPTION
Showing meaningful text on load makes for a less abrupt transition when the release version text is first being rendered.