### PR TITLE
Display the actual release date alongside a relative time

### DIFF
--- a/src/components/LatestRelease/index.jsx
+++ b/src/components/LatestRelease/index.jsx
@@ -26,7 +26,7 @@ function LatestReleaseButton() {
 
         setDownloadUrl(releaseUrl);
         setReleaseInfo(
-          `Latest Release: ${releaseTag} (${humanReadableTimeDifference} ago)`
+          `Latest Release: ${releaseTag} (${releaseDate.toDateString()} · ${humanReadableTimeDifference} ago)`
         );
       })
       .catch((error) => {


### PR DESCRIPTION
Alt tag behavior seems inconsistent, so showing a tooltip would require more effort. This might be a bit TMI, but I don't think it makes much of a difference either way... so let's keep it simple.