### PR TITLE
Add support for displaying the minimum required version (via a new "since" parameter)

### DIFF
--- a/docs/references/api/namespaces/filesystem.md
+++ b/docs/references/api/namespaces/filesystem.md
@@ -22,7 +22,7 @@ C_FileSystem.MakeDirectory("test") -- Implicit global lookup: _G.C_FileSystem
 
 Opens the given `filePath` in append mode and writes `contents` to the end of the file.
 
-<Function>
+<Function since="v0.0.1">
 <Parameters>
 <Parameter name="filePath" type="string"/>
 <Parameter name="contents" type="string"/>
@@ -38,7 +38,7 @@ Opens the given `filePath` in append mode and writes `contents` to the end of th
 
 Removes the file or directory referenced by the given `fileSystemPath`. This operation cannot be undone.
 
-<Function>
+<Function since="v0.0.1">
 <Parameters>
 <Parameter name="fileSystemPath" type="string"/>
 </Parameters>
@@ -53,7 +53,7 @@ Removes the file or directory referenced by the given `fileSystemPath`. This ope
 
 Returns `true` if the given `fileSystemPath` exists (can be accessed in read-only mode), and `false` otherwise.
 
-<Function>
+<Function since="v0.0.1">
 <Parameters>
 <Parameter name="fileSystemPath" type="string"/>
 </Parameters>
@@ -68,7 +68,7 @@ Returns `true` if the given `fileSystemPath` exists (can be accessed in read-onl
 
 Returns `true` if the given `fileSystemPath` refers to a `directory` type entry, and `false` otherwise.
 
-<Function>
+<Function since="v0.0.1">
 <Parameters>
 <Parameter name="fileSystemPath" type="string"/>
 </Parameters>
@@ -83,7 +83,7 @@ Returns `true` if the given `fileSystemPath` refers to a `directory` type entry,
 
 Returns `true` if the given `fileSystemPath` refers to a `file` type entry, and `false` otherwise.
 
-<Function>
+<Function since="v0.0.1">
 <Parameters>
 <Parameter name="fileSystemPath" type="string"/>
 </Parameters>
@@ -98,7 +98,7 @@ Returns `true` if the given `fileSystemPath` refers to a `file` type entry, and 
 
 Creates a new directory with the given `directoryPath` if one doesn't already exist. Will not create parent directories automatically.
 
-<Function>
+<Function since="v0.0.1">
 <Parameters>
 <Parameter name="directoryPath" type="string"/>
 </Parameters>
@@ -113,7 +113,7 @@ Creates a new directory with the given `directoryPath` if one doesn't already ex
 
 Creates a new directory with the given `directoryPath` if one doesn't already exist. Will create parent directories (recursively) if needed.
 
-<Function>
+<Function since="v0.0.3">
 <Parameters>
 <Parameter name="directoryPath" type="string"/>
 </Parameters>
@@ -130,7 +130,7 @@ Reads the contents of the given directory, and returns a list of all files found
 
 The `isFile` flag is always `true` in the current implementation as directories are removed after their contents have been processed.
 
-<Function>
+<Function since="v0.0.1">
 <Parameters>
 <Parameter name="directoryPath" type="string"/>
 </Parameters>
@@ -152,7 +152,7 @@ Reads the contents of the given directory tree (including nested subdirectories)
 
 The `isFile` flag is always `true` in the current implementation as directories are removed after their contents have been processed.
 
-<Function>
+<Function since="v0.0.4">
 <Parameters>
 <Parameter name="directoryPath" type="string"/>
 </Parameters>
@@ -172,7 +172,7 @@ The `isFile` flag is always `true` in the current implementation as directories 
 
 Opens the given `filePath` in read-only mode and returns the file contents as a Lua string.
 
-<Function>
+<Function since="v0.0.1">
 <Parameters>
 <Parameter name="filePath" type="string"/>
 </Parameters>
@@ -187,7 +187,7 @@ Opens the given `filePath` in read-only mode and returns the file contents as a 
 
 Opens the given `filePath` in write mode and writes `contents` to the file. Overwrites the file if it already exists.
 
-<Function>
+<Function since="v0.0.1">
 <Parameters>
 <Parameter name="filePath" type="string"/>
 <Parameter name="contents" type="string"/>

--- a/docs/references/api/namespaces/webview.md
+++ b/docs/references/api/namespaces/webview.md
@@ -20,15 +20,19 @@ C_WebView.CreateWithDevTools() -- Implicit global lookup: _G.C_WebView
 
 Creates a native WebView window, with developer tools enabled. Has no effect if called multiple times.
 
+<Function since="v0.0.2"/>
+
 ### CreateWithoutDevTools
 
 Creates a native WebView window, with developer tools disabled. Has no effect if called multiple times.
+
+<Function since="v0.0.2"/>
 
 ### EvaluateScript
 
 Sends the encoded JavaScript program `jsCodeString` to the native browser engine for (asynchronous) evaluation.
 
-<Function>
+<Function since="v0.0.2">
 <Parameters>
 <Parameter name="jsCodeString" type="string"/>
 </Parameters>
@@ -38,7 +42,7 @@ Sends the encoded JavaScript program `jsCodeString` to the native browser engine
 
 Returns `true` if a native WebView window has previously been created, and `false` otherwise.
 
-<Function>
+<Function since="v0.0.2">
 <Returns>
 <Return name="isRunning" type="boolean"/>
 </Returns>
@@ -48,7 +52,7 @@ Returns `true` if a native WebView window has previously been created, and `fals
 
 Instructs the native browser engine to (asynchronously) navigate to the given `url`. The browser may fetch additional resources.
 
-<Function>
+<Function since="v0.0.2">
 <Parameters>
 <Parameter name="url" type="string"/>
 </Parameters>
@@ -66,7 +70,7 @@ Sets the application icon for the native window that the WebView is running in. 
 
 Depending on the OS and its version, the icon may appear in different locations (e.g., OSX Dock and Windows task bar).
 
-<Function>
+<Function since="v0.0.2">
 <Parameters>
 <Parameter name="appIconPath" type="string"/>
 </Parameters>
@@ -76,7 +80,7 @@ Depending on the OS and its version, the icon may appear in different locations 
 
 Instructs the native browser engine to (asynchronously) load the given `htmlString`. The browser may _not_ fetch additional resources.
 
-<Function>
+<Function since="v0.0.2">
 <Parameters>
 <Parameter name="htmlString" type="string"/>
 </Parameters>
@@ -86,7 +90,7 @@ Instructs the native browser engine to (asynchronously) load the given `htmlStri
 
 Instructs the native browser engine to inject and execute the given `jsCodeString` on page load. You can't easily unset this currently.
 
-<Function>
+<Function since="v0.0.2">
 <Parameters>
 <Parameter name="jsCodeString" type="string"/>
 </Parameters>
@@ -96,7 +100,7 @@ Instructs the native browser engine to inject and execute the given `jsCodeStrin
 
 Resizes the native window that the WebView is running in. The exact behavior is platform-specific.
 
-<Function>
+<Function since="v0.0.2">
 <Parameters>
 <Parameter name="newWidthInPixels" type="number"/>
 <Parameter name="newHeightInPixels" type="number"/>
@@ -107,7 +111,7 @@ Resizes the native window that the WebView is running in. The exact behavior is 
 
 Updates the `title` of the native window that the WebView is running in. The exact behavior is platform-specific.
 
-<Function>
+<Function since="v0.0.2">
 <Parameters>
 <Parameter name="newWindowTitle" type="string"/>
 </Parameters>
@@ -116,6 +120,8 @@ Updates the `title` of the native window that the WebView is running in. The exa
 ### ToggleFullscreenMode
 
 Sets windowed or fullscreen mode for the native window that the WebView is running in, based on its previous state.
+
+<Function since="v0.0.2"/>
 
 ## Changelog
 

--- a/src/components/API/API.jsx
+++ b/src/components/API/API.jsx
@@ -2,9 +2,13 @@ import React from "react";
 
 import styles from "./styles.module.css";
 
-export const Function = ({ children }) => (
-  <div className={styles.function}>{children}</div>
-);
+export const Function = ({ since, children }) =>
+  (since && (
+    <>
+      <span className={styles.sinceBlock}>Available since: {since}</span>
+      <div className={styles.function}>{children}</div>
+    </>
+  )) || <></>;
 
 class NilableInfo extends React.Component {
   render() {

--- a/src/components/API/styles.module.css
+++ b/src/components/API/styles.module.css
@@ -109,3 +109,13 @@ body {
   color: black;
   font-weight: 600;
 }
+
+.sinceBlock {
+  display: inline-block;
+  margin-bottom: 0.5rem;
+  font-size: 0.8rem;
+  border: 3px solid black;
+  border-radius: 15px;
+  padding: 0.25rem 0.5rem;
+  font-weight: bold;
+}


### PR DESCRIPTION
Since (heh...) I'm not sure if this is worth doing for all the APIs, I'll just add it for the two namespaces least likely to go away.

I suspect a lot of changes in the API surface might have to happen to consolidate the naming conventions used, so I'll wait it out.