### PR TITLE
Document the dependency on PulseAudio for Linux

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -39,13 +39,13 @@ However, there is one deliberate exception (that only affects Linux users):
 
 - To avoid shipping a heavy-weight browser engine, Evo uses the operating system's native browser
 - This is Microsoft Edge on Windows, Apple's Safari on Mac OS, and WebKit (via [WebKitGTK](https://webkitgtk.org/)) on Linux
-- Since WebKit isn't usually delivered to Linux users automatically, you must manually install it
+- Since the required libraries aren't delivered to Linux users automatically, you must manually install them
   - If you're a Linux user building from source, simply follow the installation steps listed [here](/docs/how-to-guides/building-from-source#linux)
   - Otherwise, you can quickly install the relevant libraries via the package manager:
-    - Debian/Ubuntu: `apt install libgtk-3-0 libwebkit2gtk-4.0-37`
-    - ArchLinux: `pacman -S webkit2gtk gtk3`
+    - Debian/Ubuntu: `apt install libgtk-3-0 libwebkit2gtk-4.0-37 pulseaudio`
+    - ArchLinux: `pacman -S webkit2gtk gtk3 pulseaudio`
 
-This step is required even if you don't want to use WebViews (e.g., for a headless server application).
+This step is required even if you don't want to use WebViews or audio (e.g., for a headless server application).
 
 ## Basic Command-Line Usage
 

--- a/docs/how-to-guides/building-from-source.md
+++ b/docs/how-to-guides/building-from-source.md
@@ -56,16 +56,18 @@ On Ubuntu (and other Debian-derived distributions), this should install all the 
 
 ```sh
 sudo apt update
-sudo apt install make cmake ninja-build cargo binutils build-essential libgtk-3-dev libwebkit2gtk-4.0-dev --yes
+sudo apt install make cmake ninja-build cargo binutils build-essential libgtk-3-dev libwebkit2gtk-4.0-dev libpulse-dev --yes
 ```
 
-The above command works on a fresh Ubuntu system and includes the GNU compiler toolchain as well as the headers for WebViews.
+The above command works on a fresh Ubuntu system and includes the GNU compiler toolchain as well as some required development headers.
 
 For ArchLinux, some package names will be slightly different from both Windows and Ubuntu:
 
 ```sh
-pacman -Syu base-devel cmake ninja rust webkit2gtk gtk3
+pacman -Syu base-devel cmake ninja rust webkit2gtk gtk3 pulseaudio
 ```
+
+Development headers don't need to be installed separately here since they're included in the above packages.
 
 ## Standard Build Workflow
 


### PR DESCRIPTION
This is another optional (not really) dependency that must be installed manually, at least until the bindings have been moved to a separate library or were otherwise made opt-in.