### PR TITLE
Reduce the visual impact of availability tags

### DIFF
--- a/src/components/API/styles.module.css
+++ b/src/components/API/styles.module.css
@@ -130,11 +130,9 @@ body {
 }
 
 .sinceBlock {
-  display: inline-block;
-  margin-bottom: 0.5rem;
-  font-size: 0.8rem;
-  border: 3px solid black;
+  border: 1px solid var(--ifm-color-primary-darkest);
   border-radius: 15px;
-  padding: 0.25rem 0.5rem;
-  font-weight: bold;
+  padding: 0.25rem 0.75rem;
+  font-style: oblique;
+  font-size: 0.75rem;
 }


### PR DESCRIPTION
They needn't be quite as striking since they aren't going to be the most important piece of information, at all.

The lack of spacing is somewhat concerning, but I have a separate PR in the works to alleviate that.

---

![image](https://github.com/user-attachments/assets/1b00a802-e015-4db2-bc67-495e357867df)

![image](https://github.com/user-attachments/assets/d8d6e0d0-556f-4919-a6d0-ccfd4301cde5)

(The font is rendered differently due to browser defaults - should probably streamline that eventually)