### PR TITLE
Enable MDX descriptions for the API reference to be stored inside JSX blocks

### DIFF
--- a/src/components/API/API.jsx
+++ b/src/components/API/API.jsx
@@ -4,17 +4,18 @@ import styles from "./styles.module.css";
 
 class Description extends React.Component {
   render() {
-    const item = this.props.for || "Whoops";
-    const placeholderTitle = `${item}: There's nothing here yet :(`;
-    const fallback = <Placeholder title={placeholderTitle} />;
+    const fallback = (
+      <>
+        <div className={styles.descriptionBox}></div>
+      </>
+    );
 
-    const children = this.props.childre;
+    const children = this.props.children;
     if (!this.props.children) return fallback;
-    if (this.props.children) return fallback;
 
-    const hasMultipleChildren = children instanceof Array;
+    const hasMultipleChildren =
+      children instanceof Array && children.length > 0;
     const content = hasMultipleChildren ? children : [children];
-
     const description = (
       <>
         <div className={styles.descriptionBox}>{content}</div>
@@ -25,9 +26,28 @@ class Description extends React.Component {
 }
 
 class Function extends React.Component {
+  mdxTypeToPlaceholderComponent(mdxType) {
+    const placeholdersByType = {
+      Description: <Description for={mdxType} />,
+      Parameters: <Description for={mdxType} />,
+      Returns: <Description for={mdxType} />,
+      Structures: <Description for={mdxType} />,
+    };
+    return placeholdersByType[mdxType];
+  }
+  findFirstChildByType(mdxType) {
+    const fallback = this.mdxTypeToPlaceholderComponent(mdxType);
+    const children =
+      this.props.children instanceof Array ? this.props.children : [];
+    if (!children || children.length === 0) return fallback;
+    return children.find((child) => child.props.mdxType == mdxType) || fallback;
+  }
   render() {
     const since = this.props.since;
-    const children = this.props.children;
+    const description = this.findFirstChildByType("Description");
+    const parameters = this.findFirstChildByType("Parameters");
+    const returnValues = this.findFirstChildByType("Returns");
+    const structs = this.findFirstChildByType("Structures");
 
     const isRunningInDevelopmentMode = process.env.NODE_ENV !== "production";
     if (isRunningInDevelopmentMode) {
@@ -57,9 +77,23 @@ class Function extends React.Component {
     return (
       <>
         {sinceBlock}
-        <div className={styles.function}>{children}</div>
+        <div className={styles.flexColumn}>
+          <div className={styles.flexRow}>{description}</div>
+          <div className={styles.flexRow}>
+            {parameters}
+            {returnValues}
+          </div>
+          {structs}
+        </div>
+        <hr />
       </>
     );
+  }
+}
+
+class Structures extends React.Component {
+  render() {
+    return <>{this.props.children}</>;
   }
 }
 
@@ -417,4 +451,5 @@ export {
   Placeholder,
   Blocking,
   Description,
+  Structures,
 };

--- a/src/components/API/API.jsx
+++ b/src/components/API/API.jsx
@@ -2,6 +2,28 @@ import React from "react";
 
 import styles from "./styles.module.css";
 
+class Description extends React.Component {
+  render() {
+    const item = this.props.for || "Whoops";
+    const placeholderTitle = `${item}: There's nothing here yet :(`;
+    const fallback = <Placeholder title={placeholderTitle} />;
+
+    const children = this.props.childre;
+    if (!this.props.children) return fallback;
+    if (this.props.children) return fallback;
+
+    const hasMultipleChildren = children instanceof Array;
+    const content = hasMultipleChildren ? children : [children];
+
+    const description = (
+      <>
+        <div className={styles.descriptionBox}>{content}</div>
+      </>
+    );
+    return description;
+  }
+}
+
 class Function extends React.Component {
   render() {
     const since = this.props.since;
@@ -394,4 +416,5 @@ export {
   FFI,
   Placeholder,
   Blocking,
+  Description,
 };

--- a/src/components/API/styles.module.css
+++ b/src/components/API/styles.module.css
@@ -1,5 +1,11 @@
-.function {
+.flexRow {
   display: flex;
+  flex-direction: row;
+}
+
+.flexColumn {
+  display: flex;
+  flex-direction: column;
 }
 
 .functionParametersTable,
@@ -129,6 +135,9 @@ body {
   font-weight: 600;
 }
 
+.descriptionBox {
+  padding: 1rem 1rem;
+}
 .sinceBlock {
   border: 1px solid var(--ifm-color-primary-darkest);
   border-radius: 15px;

--- a/src/components/API/styles.module.css
+++ b/src/components/API/styles.module.css
@@ -136,7 +136,8 @@ body {
 }
 
 .descriptionBox {
-  padding: 1rem 1rem;
+  padding: 0rem 1rem;
+  margin-top: 1rem;
 }
 .sinceBlock {
   border: 1px solid var(--ifm-color-primary-darkest);

--- a/src/theme/MDXComponents/index.js
+++ b/src/theme/MDXComponents/index.js
@@ -26,6 +26,7 @@ import {
   FFI,
   Placeholder,
   Blocking,
+  Description,
 } from "@site/src/components/API/API";
 
 import Admonition from "@theme/Admonition";
@@ -65,5 +66,6 @@ const MDXComponents = {
   FFI: FFI,
   Placeholder: Placeholder,
   Blocking: Blocking,
+  Description: Description,
 };
 export default MDXComponents;


### PR DESCRIPTION
Inline MDX on its own would be fine, but without control over the CSS there's no way to render the description at full width. (This is surely going to fail in some edge cases, but I'd rather not mess with it any more than necessary right now.)

---

Spacing messed up because the description isn't inside the block yet:

![image](https://github.com/user-attachments/assets/b7e3c5da-4db3-41f1-9cc3-fa68c1dbee11)

Description outside the `Function` block (existing approach), with empty `Description` block:

![image](https://github.com/user-attachments/assets/a80ace24-08b9-44df-b77f-82e1691eab4d)

Moving the description inside the `Function` block (new and preferred approach):

![image](https://github.com/user-attachments/assets/b26e6aca-e490-4cec-8a46-4db9497b7c6c)

Requires the following code changes, which have yet to be applied to all functions:

```md
### path.dirname

Returns the directory path of the given `fileSystemPath` (ignoring trailing separators), similar to the Unix [dirname](https://en.wikipedia.org/wiki/Dirname) command.

<Function since="v0.0.1">
<Parameters>
```

```md
### path.dirname

<Function since="v0.0.1">
<Description>

Returns the directory path of the given `fileSystemPath` (ignoring trailing separators), similar to the Unix [dirname](https://en.wikipedia.org/wiki/Dirname) command.

</Description>
<Parameters>
```

Note: Spaces are needed according to the Docusaurus site (MDX parser issue). Otherwise `children` may be empty?
